### PR TITLE
add option to change RX/TX pins if blocked by USB bridge

### DIFF
--- a/esp-smartmeter-reader/config_esp8266.h
+++ b/esp-smartmeter-reader/config_esp8266.h
@@ -19,7 +19,7 @@ const char* MQTT_TOPIC = "homeassistant/sensor/smartmeter/state";
 
 HardwareSerial *smart_meter = &Serial;
 const int SMARTMETER_BAUD_RATE = 9600;
-#define SWAP_SERIAL  // use alternative pins for serial: GPIO15 (TX) and GPIO13 (RX) 
+// #define SWAP_SERIAL  // Use alternative pins for Serial: GPIO15 (TX) and GPIO13 (RX) 
 
 // --------------- LOGGING ---------------
 

--- a/esp-smartmeter-reader/config_esp8266.h
+++ b/esp-smartmeter-reader/config_esp8266.h
@@ -19,6 +19,7 @@ const char* MQTT_TOPIC = "homeassistant/sensor/smartmeter/state";
 
 HardwareSerial *smart_meter = &Serial;
 const int SMARTMETER_BAUD_RATE = 9600;
+#define SWAP_SERIAL  // use alternative pins for serial: GPIO15 (TX) and GPIO13 (RX) 
 
 // --------------- LOGGING ---------------
 

--- a/esp-smartmeter-reader/esp-smartmeter-reader.ino
+++ b/esp-smartmeter-reader/esp-smartmeter-reader.ino
@@ -202,6 +202,11 @@ void DecryptMessage(byte decrypted_message[74]) {
 
 void setup() {
   smart_meter->begin(SMARTMETER_BAUD_RATE);
+
+#ifdef SWAP_SERIAL      // use on ESP8266 if UART used by USB bridge:
+  smart_meter->swap();  // switch to GPIO15 (TX) and GPIO13 (RX) 
+#endif
+  
   #ifdef LOGGING_ENABLED
   Serial.begin(SERIAL_MONITOR_BAUD_RATE);
   #endif

--- a/esp-smartmeter-reader/esp-smartmeter-reader.ino
+++ b/esp-smartmeter-reader/esp-smartmeter-reader.ino
@@ -202,11 +202,9 @@ void DecryptMessage(byte decrypted_message[74]) {
 
 void setup() {
   smart_meter->begin(SMARTMETER_BAUD_RATE);
-
-#ifdef SWAP_SERIAL      // use on ESP8266 if UART used by USB bridge:
-  smart_meter->swap();  // switch to GPIO15 (TX) and GPIO13 (RX) 
-#endif
-  
+  #ifdef SWAP_SERIAL
+    smart_meter->swap();  // ESP8266: Remap Serial (UART0) to GPIO15 (TX) and GPIO13 (RX)
+  #endif
   #ifdef LOGGING_ENABLED
   Serial.begin(SERIAL_MONITOR_BAUD_RATE);
   #endif


### PR DESCRIPTION
Since on many 8266 boards the hardware UART is already used by the USB-bridge, I added the option to swap the serial pins to  GPIO15 (TX) and GPIO13 (RX) .
(See https://arduino.esp8266.com/Arduino/versions/2.1.0-rc2/doc/reference.html#serial)
I added a #define in config_esp8266.h for this.

Tested it on an Wemos D1 mini, works fine at my home!