### PR TITLE
Add suppport for Siemens Smart Meters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ESP8266 has two UARTs, however, UART1 is TX-only. Therefore, we have to use 
 
 ## Configuring and uploading the sketch
 
-After you cloned the repository, rename `config_esp32.h` or `config_esp8266.h` (depending on which device you have) to `config.h` and open it. Adjust the settings and save the file (the decryption key can be obtained in the [Smart Meter Webportal](https://smartmeter-web.wienernetze.at/)). Be sure to uncomment the correct settings for your brand of meter in the "SMART METER" section. After that open `esp-smartmeter-reader.ino` in the Arduino IDE. The sketch uses the following libaries:
+After you cloned the repository, rename `config_esp32.h` or `config_esp8266.h` (depending on which device you have) to `config.h` and open it. Adjust the settings and save the file (the decryption key can be obtained in the [Smart Meter Webportal](https://smartmeter-web.wienernetze.at/)). Don't forget to uncomment the settings for your specific smart meter brand in the "SMART METER" section. After that open `esp-smartmeter-reader.ino` in the Arduino IDE. The sketch uses the following libaries:
 
 * [FastCRC](https://github.com/FrankBoesing/FastCRC)
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 [![Compile Sketch for ESP32](https://github.com/aldadic/esp-smartmeter-reader/actions/workflows/compile_esp32.yml/badge.svg)](https://github.com/aldadic/esp-smartmeter-reader/actions/workflows/compile_esp32.yml)
 [![Compile Sketch for ESP8266](https://github.com/aldadic/esp-smartmeter-reader/actions/workflows/compile_esp8266.yml/badge.svg)](https://github.com/aldadic/esp-smartmeter-reader/actions/workflows/compile_esp8266.yml)
 
-This Arduino sketch was made to read and decrypt the data from my Smart Meter (Landis+Gyr E450 operated by Wiener Netze) and publish it via MQTT. This way the data can be easily integrated into Home Assistant (see [here](#home-assistant-integration)). This sketch works both on the ESP32 and ESP8266. This project was only possible with the information from [this thread](https://www.lteforum.at/mobilfunk/wiener-netze-smart-meter-auslesen.16222/); thank you to everyone who shared their findings (especially the user "pocki").
+This Arduino sketch was made to read and decrypt the data from my smart meter operated by Wiener Netze and publish it via MQTT. This way the data can be easily integrated into Home Assistant (see [here](#home-assistant-integration)). This sketch works both on the ESP32 and ESP8266. This project was only possible with the information from [this thread](https://www.lteforum.at/mobilfunk/wiener-netze-smart-meter-auslesen.16222/); thank you to everyone who shared their findings (especially the user "pocki").
+
+## Supported smart meters
+
+The sketch supports the following smart meter manufacturers:
+
+* Landis+Gyr (tested with Landis+Gyr E450)
+* Siemens (thanks [@nomike](https://github.com/nomike))
 
 ## Setting up the ESP32 / ESP8266
 
-To be able to use the optical user interface of the Smart Meter an [IR reader with TTL-Interface](https://wiki.volkszaehler.org/hardware/controllers/ir-schreib-lesekopf-ttl-ausgang) is needed (I am using [this](https://www.ebay.de/itm/313460034498) one). This device reads the data from the optical user interface and transmits it to the ESP32 or ESP8266 via serial communication. Because normally UART0 is used for the USB connection (e.g. flashing the device, serial monitor, etc.), it makes sense to use UART2 for the IR reader. This is why we connect the IR reader to the ESP32 in the following way:
+To be able to use the optical user interface of the smart meter an [IR reader with TTL-Interface](https://wiki.volkszaehler.org/hardware/controllers/ir-schreib-lesekopf-ttl-ausgang) is needed (I am using [this](https://www.ebay.de/itm/313460034498) one). This device reads the data from the optical user interface and transmits it to the ESP32 or ESP8266 via serial communication. Because normally UART0 is used for the USB connection (e.g. flashing the device, serial monitor, etc.), it makes sense to use UART2 for the IR reader. This is why we connect the IR reader to the ESP32 in the following way:
 
 | IR reader  | ESP32        |
 | ---------- | ------------ |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The ESP8266 has two UARTs, however, UART1 is TX-only. Therefore, we have to use 
 
 ## Configuring and uploading the sketch
 
-After you cloned the repository, rename `config_esp32.h` or `config_esp8266.h` (depending on which device you have) to `config.h` and open it. Adjust the settings and save the file (the decryption key can be obtained in the [Smart Meter Webportal](https://smartmeter-web.wienernetze.at/)). After that open `esp-smartmeter-reader.ino` in the Arduino IDE. The sketch uses the following libaries:
+After you cloned the repository, rename `config_esp32.h` or `config_esp8266.h` (depending on which device you have) to `config.h` and open it. Adjust the settings and save the file (the decryption key can be obtained in the [Smart Meter Webportal](https://smartmeter-web.wienernetze.at/)). Be sure to uncomment the correct settings for your brand of meter in the "SMART METER" section. After that open `esp-smartmeter-reader.ino` in the Arduino IDE. The sketch uses the following libaries:
 
 * [FastCRC](https://github.com/FrankBoesing/FastCRC)
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson)

--- a/esp-smartmeter-reader/config_esp32.h
+++ b/esp-smartmeter-reader/config_esp32.h
@@ -20,6 +20,18 @@ const char* MQTT_TOPIC = "homeassistant/sensor/smartmeter/state";
 HardwareSerial *smart_meter = &Serial2;
 const int SMARTMETER_BAUD_RATE = 9600;
 
+// // Landys & Gyr
+// const unsigned int IV_ADD = 0;
+// const unsigned int PAYLOAD_ADD = 0;
+// const unsigned int MESSAGE_LENGTH = 105;
+// const unsigned int PAYLOAD_LENGTH = 74;
+
+// // Siemens
+// const unsigned int IV_ADD = 2;
+// const unsigned int PAYLOAD_ADD = 18;
+// const unsigned int MESSAGE_LENGTH = 125; // Landys & Gyr: 105 ; 
+// const unsigned int PAYLOAD_LENGTH = 90; // 74
+
 // --------------- LOGGING ---------------
 
 HardwareSerial *logger = &Serial;

--- a/esp-smartmeter-reader/config_esp32.h
+++ b/esp-smartmeter-reader/config_esp32.h
@@ -21,10 +21,10 @@ HardwareSerial *smart_meter = &Serial2;
 const int SMARTMETER_BAUD_RATE = 9600;
 
 // -- Landis+Gyr
-// const unsigned int IV_ADD = 0;
-// const unsigned int PAYLOAD_ADD = 0;
-// const unsigned int MESSAGE_LENGTH = 105;
-// const unsigned int PAYLOAD_LENGTH = 74;
+const unsigned int IV_ADD = 0;
+const unsigned int PAYLOAD_ADD = 0;
+const unsigned int MESSAGE_LENGTH = 105;
+const unsigned int PAYLOAD_LENGTH = 74;
 
 // -- Siemens
 // const unsigned int IV_ADD = 2;

--- a/esp-smartmeter-reader/config_esp32.h
+++ b/esp-smartmeter-reader/config_esp32.h
@@ -20,17 +20,17 @@ const char* MQTT_TOPIC = "homeassistant/sensor/smartmeter/state";
 HardwareSerial *smart_meter = &Serial2;
 const int SMARTMETER_BAUD_RATE = 9600;
 
-// // Landys & Gyr
+// -- Landis+Gyr
 // const unsigned int IV_ADD = 0;
 // const unsigned int PAYLOAD_ADD = 0;
 // const unsigned int MESSAGE_LENGTH = 105;
 // const unsigned int PAYLOAD_LENGTH = 74;
 
-// // Siemens
+// -- Siemens
 // const unsigned int IV_ADD = 2;
 // const unsigned int PAYLOAD_ADD = 18;
-// const unsigned int MESSAGE_LENGTH = 125; // Landys & Gyr: 105 ; 
-// const unsigned int PAYLOAD_LENGTH = 90; // 74
+// const unsigned int MESSAGE_LENGTH = 125;
+// const unsigned int PAYLOAD_LENGTH = 90;
 
 // --------------- LOGGING ---------------
 

--- a/esp-smartmeter-reader/config_esp8266.h
+++ b/esp-smartmeter-reader/config_esp8266.h
@@ -19,7 +19,19 @@ const char* MQTT_TOPIC = "homeassistant/sensor/smartmeter/state";
 
 HardwareSerial *smart_meter = &Serial;
 const int SMARTMETER_BAUD_RATE = 9600;
-#define SWAP_SERIAL  // Use alternative pins for Serial: GPIO15 (TX) and GPIO13 (RX) 
+#define SWAP_SERIAL  // Use alternative pins for Serial: GPIO15 (TX) and GPIO13 (RX)
+
+// // Landys & Gyr
+// const unsigned int IV_ADD = 0;
+// const unsigned int PAYLOAD_ADD = 0;
+// const unsigned int MESSAGE_LENGTH = 105;
+// const unsigned int PAYLOAD_LENGTH = 74;
+
+// // Siemens
+// const unsigned int IV_ADD = 2;
+// const unsigned int PAYLOAD_ADD = 18;
+// const unsigned int MESSAGE_LENGTH = 125; // Landys & Gyr: 105 ; 
+// const unsigned int PAYLOAD_LENGTH = 90; // 74
 
 // --------------- LOGGING ---------------
 

--- a/esp-smartmeter-reader/config_esp8266.h
+++ b/esp-smartmeter-reader/config_esp8266.h
@@ -21,17 +21,17 @@ HardwareSerial *smart_meter = &Serial;
 const int SMARTMETER_BAUD_RATE = 9600;
 #define SWAP_SERIAL  // Use alternative pins for Serial: GPIO15 (TX) and GPIO13 (RX)
 
-// // Landys & Gyr
+// -- Landis+Gyr
 // const unsigned int IV_ADD = 0;
 // const unsigned int PAYLOAD_ADD = 0;
 // const unsigned int MESSAGE_LENGTH = 105;
 // const unsigned int PAYLOAD_LENGTH = 74;
 
-// // Siemens
+// -- Siemens
 // const unsigned int IV_ADD = 2;
 // const unsigned int PAYLOAD_ADD = 18;
-// const unsigned int MESSAGE_LENGTH = 125; // Landys & Gyr: 105 ; 
-// const unsigned int PAYLOAD_LENGTH = 90; // 74
+// const unsigned int MESSAGE_LENGTH = 125;
+// const unsigned int PAYLOAD_LENGTH = 90;
 
 // --------------- LOGGING ---------------
 

--- a/esp-smartmeter-reader/config_esp8266.h
+++ b/esp-smartmeter-reader/config_esp8266.h
@@ -22,10 +22,10 @@ const int SMARTMETER_BAUD_RATE = 9600;
 #define SWAP_SERIAL  // Use alternative pins for Serial: GPIO15 (TX) and GPIO13 (RX)
 
 // -- Landis+Gyr
-// const unsigned int IV_ADD = 0;
-// const unsigned int PAYLOAD_ADD = 0;
-// const unsigned int MESSAGE_LENGTH = 105;
-// const unsigned int PAYLOAD_LENGTH = 74;
+const unsigned int IV_ADD = 0;
+const unsigned int PAYLOAD_ADD = 0;
+const unsigned int MESSAGE_LENGTH = 105;
+const unsigned int PAYLOAD_LENGTH = 74;
 
 // -- Siemens
 // const unsigned int IV_ADD = 2;

--- a/esp-smartmeter-reader/esp-smartmeter-reader.ino
+++ b/esp-smartmeter-reader/esp-smartmeter-reader.ino
@@ -56,7 +56,7 @@ void ReconnectMQTT() {
 
 // --------------- SERIAL READER ---------------
 
-const unsigned int MESSAGE_LENGTH = 105;
+
 byte received_data[MESSAGE_LENGTH];
 
 void ReadSerialData() {
@@ -73,7 +73,7 @@ void ReadSerialData() {
         received_data[0] = 0x7E;
         received_data[1] = 0xA0;
         pos = 2;
-      } 
+      }
     } else {
       if (pos < MESSAGE_LENGTH) {
         received_data[pos] = current_byte;
@@ -104,30 +104,30 @@ void ParseReceivedData() {
   }
 
   // Decrypt message
-  byte decrypted_message[74];
+  byte decrypted_message[PAYLOAD_LENGTH];
   DecryptMessage(decrypted_message);
 
   // Extract time and date from decrypted message
-  int year = BytesToInt(decrypted_message, 22, 24);
-  int month = BytesToInt(decrypted_message, 24, 25);
-  int day = BytesToInt(decrypted_message, 25, 26);
-  int hour = BytesToInt(decrypted_message, 27, 28);
-  int minute = BytesToInt(decrypted_message, 28, 29);
-  int second = BytesToInt(decrypted_message, 29, 30);
+  int year = BytesToInt(decrypted_message, 22 + PAYLOAD_ADD, 24 + PAYLOAD_ADD);
+  int month = BytesToInt(decrypted_message, 24 + PAYLOAD_ADD, 25 + PAYLOAD_ADD);
+  int day = BytesToInt(decrypted_message, 25 + PAYLOAD_ADD, 26 + PAYLOAD_ADD);
+  int hour = BytesToInt(decrypted_message, 27 + PAYLOAD_ADD, 28 + PAYLOAD_ADD);
+  int minute = BytesToInt(decrypted_message, 28 + PAYLOAD_ADD, 29 + PAYLOAD_ADD);
+  int second = BytesToInt(decrypted_message, 29 + PAYLOAD_ADD, 30 + PAYLOAD_ADD);
   char timestamp[20];
   sprintf(timestamp, "%02d.%02d.%04d %02d:%02d:%02d", day, month, year, hour, minute, second);
 
   // Create JSON
   StaticJsonDocument<256> doc;
   doc["timestamp"] = timestamp;
-  doc["+A"] = BytesToInt(decrypted_message, 35, 39)/1000.0;
-  doc["-A"] = BytesToInt(decrypted_message, 40, 44)/1000.0;
-  doc["+R"] = BytesToInt(decrypted_message, 45, 49)/1000.0;
-  doc["-R"] = BytesToInt(decrypted_message, 50, 54)/1000.0;
-  doc["+P"] = BytesToInt(decrypted_message, 55, 59);
-  doc["-P"] = BytesToInt(decrypted_message, 60, 64);
-  doc["+Q"] = BytesToInt(decrypted_message, 65, 69);
-  doc["-Q"] = BytesToInt(decrypted_message, 70, 74);
+  doc["+A"] = BytesToInt(decrypted_message, 35 + PAYLOAD_ADD, 39 + PAYLOAD_ADD)/1000.0;
+  doc["-A"] = BytesToInt(decrypted_message, 40 + PAYLOAD_ADD, 44 + PAYLOAD_ADD)/1000.0;
+  doc["+R"] = BytesToInt(decrypted_message, 45 + PAYLOAD_ADD, 49 + PAYLOAD_ADD)/1000.0;
+  doc["-R"] = BytesToInt(decrypted_message, 50 + PAYLOAD_ADD, 54 + PAYLOAD_ADD)/1000.0;
+  doc["+P"] = BytesToInt(decrypted_message, 55 + PAYLOAD_ADD, 59 + PAYLOAD_ADD);
+  doc["-P"] = BytesToInt(decrypted_message, 60 + PAYLOAD_ADD, 64 + PAYLOAD_ADD);
+  doc["+Q"] = BytesToInt(decrypted_message, 65 + PAYLOAD_ADD, 69 + PAYLOAD_ADD);
+  doc["-Q"] = BytesToInt(decrypted_message, 70 + PAYLOAD_ADD, 74 + PAYLOAD_ADD);
   char payload[256];
   serializeJson(doc, payload);
 
@@ -143,10 +143,10 @@ void ParseReceivedData() {
 FastCRC16 CRC16;
 
 bool ValidateCRC() {
-  byte message[101];
-  memcpy(message, received_data + 1, 101);
-  int crc = CRC16.x25(message, 101);
-  int expected_crc = received_data[103] * 256 + received_data[102];
+  byte message[MESSAGE_LENGTH - 4];
+  memcpy(message, received_data + 1, MESSAGE_LENGTH - 4);
+  int crc = CRC16.x25(message, MESSAGE_LENGTH - 4);
+  int expected_crc = received_data[MESSAGE_LENGTH - 2] * 256 + received_data[MESSAGE_LENGTH - 3];
   if (crc != expected_crc) {
     logger->println("WARNING: CRC check failed");
     return false;
@@ -162,20 +162,20 @@ mbedtls_aes_context aes;
 CTR<AES128> ctr;
 #endif
 
-void DecryptMessage(byte decrypted_message[74]) {
+void DecryptMessage(byte decrypted_message[PAYLOAD_LENGTH]) {
   // Extract message and iv from received data
-  byte encrypted_message[74] = {0};
-  memcpy(encrypted_message, received_data + 28, 74);
+  byte encrypted_message[PAYLOAD_LENGTH] = {0};
+  memcpy(encrypted_message, received_data + 28 + IV_ADD, PAYLOAD_LENGTH);
   byte iv[16] = {0};
-  memcpy(iv, received_data + 14, 8);
-  memcpy(iv + 8, received_data + 24, 4);
-  iv[15] = 0x02; 
+  memcpy(iv, received_data + 14 + IV_ADD, 8);
+  memcpy(iv + 8, received_data + 24 + IV_ADD, 4);
+  iv[15] = 0x02;
 
   // Decrypt message
   #if defined(ESP32)
   size_t nc_off = 0;
   unsigned char stream_block[16] = {0};
-  mbedtls_aes_crypt_ctr(&aes, 74, &nc_off, iv, stream_block, encrypted_message, decrypted_message);
+  mbedtls_aes_crypt_ctr(&aes, PAYLOAD_LENGTH, &nc_off, iv, stream_block, encrypted_message, decrypted_message);
   #elif defined(ESP8266)
   ctr.setIV(iv, sizeof(iv));
   ctr.decrypt(decrypted_message, encrypted_message, sizeof(encrypted_message));

--- a/esp-smartmeter-reader/esp-smartmeter-reader.ino
+++ b/esp-smartmeter-reader/esp-smartmeter-reader.ino
@@ -56,7 +56,6 @@ void ReconnectMQTT() {
 
 // --------------- SERIAL READER ---------------
 
-
 byte received_data[MESSAGE_LENGTH];
 
 void ReadSerialData() {


### PR DESCRIPTION
I've added support for Siemens Smart Meters.
I made the whole thing configurable, so more meters could be added in the future.

The website of Wiener Netze provides a user manual for Iskrameco meters, but I don't have one of these, so I can't test this.

My Siemens meter is read just fine with this additions.